### PR TITLE
Video 6759 results mobile styling

### DIFF
--- a/src/components/AppStateProvider/AppStateProvider.test.tsx
+++ b/src/components/AppStateProvider/AppStateProvider.test.tsx
@@ -59,6 +59,17 @@ describe('the isDownButtonDisabled function', () => {
     expect(isDownButtonDisabled(mockCurrentState)).toBe(true);
   });
 
+  it('should return true if there is a token error when starting the preflight test', () => {
+    const mockCurrentState = {
+      ...initialState,
+      activePane: ActivePane.Connectivity,
+      preflightTestInProgress: false,
+      preflightTest: { ...initialState.preflightTest, tokenError: Error() },
+      bitrateTestInProgress: false,
+    };
+    expect(isDownButtonDisabled(mockCurrentState)).toBe(true);
+  });
+
   it('should return true when preflight test and/or bitrate test is in progress', () => {
     const mockCurrentState = {
       ...initialState,

--- a/src/components/AppStateProvider/AppStateProvider.tsx
+++ b/src/components/AppStateProvider/AppStateProvider.tsx
@@ -145,7 +145,10 @@ export const isDownButtonDisabled = (currentState: stateType) => {
 
   const connectionFailedOrLoading =
     activePane === ActivePane.Connectivity &&
-    (preflightTestInProgress || bitrateTestInProgress || preflightTest.error !== null);
+    (preflightTestInProgress ||
+      bitrateTestInProgress ||
+      preflightTest.error !== null ||
+      preflightTest.tokenError !== null);
 
   const deviceTestErrors =
     !!audioInputTestReport?.errors.length ||

--- a/src/components/MainContent/MainContent.test.tsx
+++ b/src/components/MainContent/MainContent.test.tsx
@@ -129,6 +129,7 @@ describe('the MainContent component', () => {
         activePane: 0,
         preflightTest: {
           progress: null,
+          tokenError: null,
         },
         downButtonDisabled: false,
       },
@@ -142,6 +143,9 @@ describe('the MainContent component', () => {
     mockUseAppStateContext.mockImplementation(() => ({
       state: {
         activePane: ActivePane.CameraTest,
+        preflightTest: {
+          tokenError: null,
+        },
         videoInputTestReport: {
           errors: ['mockErrors'],
         },
@@ -243,6 +247,9 @@ describe('the MainContent component', () => {
       mockUseAppStateContext.mockImplementation(() => ({
         state: {
           activePane: ActivePane.CameraTest,
+          preflightTest: {
+            tokenError: null,
+          },
           videoInputTestReport: {
             errors: ['mockErrors'],
           },
@@ -258,6 +265,9 @@ describe('the MainContent component', () => {
       mockUseAppStateContext.mockImplementation(() => ({
         state: {
           activePane: ActivePane.AudioTest,
+          preflightTest: {
+            tokenError: null,
+          },
           audioInputTestReport: {
             errors: ['mockErrors'],
           },
@@ -338,6 +348,9 @@ describe('the MainContent component', () => {
       mockUseAppStateContext.mockImplementation(() => ({
         state: {
           activePane: ActivePane.BrowserTest,
+          preflightTest: {
+            tokenError: null,
+          },
           preflightTestInProgress: false,
         },
       }));
@@ -351,6 +364,9 @@ describe('the MainContent component', () => {
     mockUseAppStateContext.mockImplementation(() => ({
       state: {
         activePane: ActivePane.CameraTest,
+        preflightTest: {
+          tokenError: null,
+        },
         videoInputTestReport: {
           errors: ['mockErrors'],
         },
@@ -366,6 +382,9 @@ describe('the MainContent component', () => {
     mockUseAppStateContext.mockImplementation(() => ({
       state: {
         activePane: ActivePane.AudioTest,
+        preflightTest: {
+          tokenError: null,
+        },
         audioInputTestReport: {
           errors: ['mockErrors'],
         },
@@ -381,6 +400,9 @@ describe('the MainContent component', () => {
     mockUseAppStateContext.mockImplementation(() => ({
       state: {
         activePane: ActivePane.AudioTest,
+        preflightTest: {
+          tokenError: null,
+        },
         audioOutputTestReport: {
           errors: ['mockErrors'],
         },
@@ -396,6 +418,9 @@ describe('the MainContent component', () => {
     mockUseAppStateContext.mockImplementation(() => ({
       state: {
         activePane: ActivePane.AudioTest,
+        preflightTest: {
+          tokenError: null,
+        },
         audioOutputTestReport: {
           errors: ['No audio detected'],
         },

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import clsx from 'clsx';
-import { Button, makeStyles, useTheme, Theme, useMediaQuery } from '@material-ui/core';
+import { Button, makeStyles, useTheme, Theme, useMediaQuery, Hidden } from '@material-ui/core';
 import Video from 'twilio-video';
 
 import { ActivePane, useAppStateContext } from '../AppStateProvider/AppStateProvider';
@@ -202,18 +202,20 @@ export function MainContent() {
           })}
         </div>
       </div>
-      <div className={classes.buttonContainer}>
-        <Button
-          variant="outlined"
-          onClick={() => dispatch({ type: 'previous-pane' })}
-          disabled={!ActivePane[state.activePane - 1] || isSnackbarOpen}
-        >
-          <ArrowUp />
-        </Button>
-        <Button variant="outlined" onClick={nextPane} disabled={state.downButtonDisabled}>
-          <ArrowDown />
-        </Button>
-      </div>
+      <Hidden smDown>
+        <div className={classes.buttonContainer}>
+          <Button
+            variant="outlined"
+            onClick={() => dispatch({ type: 'previous-pane' })}
+            disabled={!ActivePane[state.activePane - 1] || isSnackbarOpen}
+          >
+            <ArrowUp />
+          </Button>
+          <Button variant="outlined" onClick={nextPane} disabled={state.downButtonDisabled}>
+            <ArrowDown />
+          </Button>
+        </div>
+      </Hidden>
     </>
   );
 }

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef } from 'react';
 import clsx from 'clsx';
-import { Button, makeStyles, useTheme, Theme, useMediaQuery, Hidden } from '@material-ui/core';
+import { Button, makeStyles, useTheme, Theme, useMediaQuery } from '@material-ui/core';
 import Video from 'twilio-video';
 
 import { ActivePane, useAppStateContext } from '../AppStateProvider/AppStateProvider';
@@ -100,7 +100,7 @@ const useStyles = makeStyles((theme: Theme) => ({
       },
     },
     [theme.breakpoints.down('sm')]: {
-      position: 'fixed',
+      display: 'none',
     },
   },
 }));
@@ -202,20 +202,18 @@ export function MainContent() {
           })}
         </div>
       </div>
-      <Hidden smDown>
-        <div className={classes.buttonContainer}>
-          <Button
-            variant="outlined"
-            onClick={() => dispatch({ type: 'previous-pane' })}
-            disabled={!ActivePane[state.activePane - 1] || isSnackbarOpen}
-          >
-            <ArrowUp />
-          </Button>
-          <Button variant="outlined" onClick={nextPane} disabled={state.downButtonDisabled}>
-            <ArrowDown />
-          </Button>
-        </div>
-      </Hidden>
+      <div className={classes.buttonContainer}>
+        <Button
+          variant="outlined"
+          onClick={() => dispatch({ type: 'previous-pane' })}
+          disabled={!ActivePane[state.activePane - 1] || isSnackbarOpen}
+        >
+          <ArrowUp />
+        </Button>
+        <Button variant="outlined" onClick={nextPane} disabled={state.downButtonDisabled}>
+          <ArrowDown />
+        </Button>
+      </div>
     </>
   );
 }

--- a/src/components/MainContent/MainContent.tsx
+++ b/src/components/MainContent/MainContent.tsx
@@ -163,6 +163,7 @@ export function MainContent() {
   const devicesPermitted = state.audioGranted && state.videoGranted;
   const testsInProgress = state.preflightTestInProgress || state.bitrateTestInProgress;
   const onLoadingScreen = state.activePane === ActivePane.Connectivity && testsInProgress;
+  const preflightErrors = state.preflightTest.tokenError !== null || state.preflightTest.error !== null;
 
   const deviceTestErrors =
     !!state.audioInputTestReport?.errors.length ||
@@ -182,6 +183,7 @@ export function MainContent() {
               state.activePane === ActivePane.DeviceCheck ||
               state.activePane === ActivePane.DeviceError ||
               onLoadingScreen ||
+              (state.activePane === ActivePane.Connectivity && preflightErrors) ||
               (state.activePane === ActivePane.BrowserTest && (testsInProgress || !Video.isSupported)),
           })}
         >

--- a/src/components/Snackbar/Snackbar.tsx
+++ b/src/components/Snackbar/Snackbar.tsx
@@ -1,32 +1,38 @@
 import { SmallError } from '../../icons/SmallError';
-import { makeStyles, Typography, Button } from '@material-ui/core';
+import { makeStyles, Typography, Button, Theme, createStyles } from '@material-ui/core';
 import MUISnackbar from '@material-ui/core/Snackbar';
 
-const useStyles = makeStyles({
-  container: {
-    display: 'flex',
-    justifyContent: 'space-between',
-    width: '400px',
-    minHeight: '50px',
-    background: 'white',
-    padding: '1em',
-    borderRadius: '3px',
-    boxShadow: '0 12px 24px 4px rgba(40,42,43,0.2)',
-    borderLeft: '4px solid #D61F1F',
-  },
-  contentContainer: {
-    display: 'flex',
-    lineHeight: 1.8,
-  },
-  iconContainer: {
-    display: 'flex',
-    padding: '0 1.3em 0 0.3em',
-    transform: 'translateY(3px)',
-  },
-  headline: {
-    fontWeight: 'bold',
-  },
-});
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    container: {
+      display: 'flex',
+      justifyContent: 'space-between',
+      width: '400px',
+      minHeight: '50px',
+      background: 'white',
+      padding: '1em',
+      borderRadius: '3px',
+      boxShadow: '0 12px 24px 4px rgba(40,42,43,0.2)',
+      borderLeft: '4px solid #D61F1F',
+      [theme.breakpoints.down('sm')]: {
+        width: '100%',
+        marginLeft: '0.5em',
+      },
+    },
+    contentContainer: {
+      display: 'flex',
+      lineHeight: 1.8,
+    },
+    iconContainer: {
+      display: 'flex',
+      padding: '0 1.3em 0 0.3em',
+      transform: 'translateY(3px)',
+    },
+    headline: {
+      fontWeight: 'bold',
+    },
+  })
+);
 
 interface SnackbarProps {
   open: boolean;

--- a/src/components/panes/BrowserTest/UnsupportedBrowser/UnsupportedBrowser.tsx
+++ b/src/components/panes/BrowserTest/UnsupportedBrowser/UnsupportedBrowser.tsx
@@ -34,13 +34,8 @@ const useStyles = makeStyles((theme: Theme) =>
       display: 'flex',
     },
     errorIcon: {
-      position: 'absolute',
-      right: 'calc(100% + 15px)',
-      [theme.breakpoints.down('sm')]: {
-        position: 'relative',
-        right: '0',
-        marginBottom: '0.5em',
-      },
+      display: 'inline-block',
+      marginRight: '10px',
     },
     caption: {
       marginTop: '1.3em',
@@ -94,7 +89,7 @@ export function UnsupportedBrowser() {
             <Typography variant="h1" gutterBottom className={classes.heading}>
               <div className={classes.errorIcon}>
                 <ErrorIcon />
-              </div>{' '}
+              </div>
               New browser needed
             </Typography>
             <Typography variant="body1" gutterBottom>

--- a/src/components/panes/BrowserTest/UnsupportedBrowser/__snapshots__/UnsupportedBrowser.test.tsx.snap
+++ b/src/components/panes/BrowserTest/UnsupportedBrowser/__snapshots__/UnsupportedBrowser.test.tsx.snap
@@ -21,7 +21,6 @@ exports[`the UnsupportedBrowser component should render correctly 1`] = `
           >
             <ErrorIcon />
           </div>
-           
           New browser needed
         </WithStyles(ForwardRef(Typography))>
         <WithStyles(ForwardRef(Typography))

--- a/src/components/panes/Connectivity/ConnectionFailed/ConnectionFailed.tsx
+++ b/src/components/panes/Connectivity/ConnectionFailed/ConnectionFailed.tsx
@@ -17,13 +17,8 @@ const useStyles = makeStyles((theme) =>
       marginTop: '20px',
     },
     errorIcon: {
-      position: 'absolute',
-      right: 'calc(100% + 15px)',
-      [theme.breakpoints.down('sm')]: {
-        position: 'relative',
-        right: '0',
-        marginBottom: '0.5em',
-      },
+      display: 'inline-block',
+      marginRight: '10px',
     },
     paperContainer: {
       float: 'right',

--- a/src/components/panes/DeviceSetup/PermissionError/PermissionError.tsx
+++ b/src/components/panes/DeviceSetup/PermissionError/PermissionError.tsx
@@ -27,13 +27,8 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     errorIcon: {
-      position: 'absolute',
-      right: 'calc(100% + 15px)',
-      [theme.breakpoints.down('sm')]: {
-        position: 'relative',
-        right: '0',
-        marginBottom: '0.5em',
-      },
+      display: 'inline-block',
+      marginRight: '10px',
     },
     header: {
       float: 'left',
@@ -117,7 +112,7 @@ export function PermissionError() {
           <Typography variant="h1" gutterBottom className={classes.heading}>
             <div className={classes.errorIcon}>
               <ErrorIcon />
-            </div>{' '}
+            </div>
             {headline}
           </Typography>
 

--- a/src/components/panes/Quality/PoorQuality/PoorQuality.tsx
+++ b/src/components/panes/Quality/PoorQuality/PoorQuality.tsx
@@ -17,13 +17,8 @@ const useStyles = makeStyles((theme: Theme) =>
       position: 'relative',
     },
     errorIcon: {
-      position: 'absolute',
-      right: 'calc(100% + 15px)',
-      [theme.breakpoints.down('sm')]: {
-        position: 'relative',
-        right: '0',
-        marginBottom: '0.5em',
-      },
+      display: 'inline-block',
+      marginRight: '10px',
     },
     paper: {
       padding: '1.2em',

--- a/src/components/panes/Results/Results.tsx
+++ b/src/components/panes/Results/Results.tsx
@@ -1,4 +1,4 @@
-import { makeStyles, Button, Container, Grid, Typography } from '@material-ui/core';
+import { makeStyles, Button, Container, Grid, Typography, Theme, createStyles, Hidden } from '@material-ui/core';
 import { ActivePane, useAppStateContext } from '../../AppStateProvider/AppStateProvider';
 import { CheckMark } from '../../../icons/CheckMark';
 import { DownloadIcon } from '../../../icons/DownloadIcon';
@@ -8,28 +8,65 @@ import { SmallError } from '../../../icons/SmallError';
 import SomeFailed from './SomeFailed.png';
 import TestsPassed from './TestsPassed.png';
 
-const useStyles = makeStyles({
-  resultContainer: {
-    marginTop: '2em',
-    '&:not(:last-child)': {
-      paddingBottom: '2em',
-      borderBottom: '0.1em solid #8891AA',
+const useStyles = makeStyles((theme: Theme) =>
+  createStyles({
+    header: {
+      float: 'left',
+      [theme.breakpoints.down('md')]: {
+        float: 'initial',
+      },
     },
-  },
-  iconContainer: {
-    display: 'flex',
-    '& svg': {
-      margin: '0.2em 0.8em 0 0',
+    buttonContainer: {
+      display: 'inline-flex',
+      flexWrap: 'wrap',
+      gap: '1em',
+      width: '100%',
     },
-  },
-  downloadButton: {
-    marginRight: '1.5em',
-    '& svg': {
-      position: 'relative',
-      left: '-5px',
+    resultsList: {
+      float: 'right',
+      [theme.breakpoints.down('md')]: {
+        float: 'initial',
+      },
     },
-  },
-});
+    resultContainer: {
+      marginTop: '1.5em',
+      '&:not(:last-child)': {
+        paddingBottom: '1.5em',
+        borderBottom: '0.1em solid #8891AA',
+      },
+      [theme.breakpoints.down('md')]: {
+        '&:last-child': {
+          paddingBottom: '1.5em',
+        },
+      },
+    },
+    iconContainer: {
+      display: 'flex',
+      '& svg': {
+        margin: '0.2em 0.8em 0 0',
+      },
+    },
+    downloadButton: {
+      '& svg': {
+        position: 'relative',
+        left: '-5px',
+      },
+    },
+    restartButton: {
+      backgroundColor: '#FFFFFF',
+      borderColor: '#8891AA',
+    },
+    illustration: {
+      marginTop: '7em',
+    },
+    hardwareButton: {
+      marginRight: '1.5em',
+    },
+    gutterBottom: {
+      marginBottom: '1em',
+    },
+  })
+);
 
 export function Results() {
   const { state, downloadFinalTestResults, dispatch } = useAppStateContext();
@@ -42,8 +79,8 @@ export function Results() {
   return (
     <>
       <Container>
-        <Grid container justifyContent="space-between">
-          <Grid item md={5}>
+        <div>
+          <Grid item lg={5} className={classes.header}>
             <Typography variant="h1" gutterBottom>
               {testsPassed ? 'All tests passed!' : 'Some tests failed'}
             </Typography>
@@ -61,63 +98,66 @@ export function Results() {
               </Typography>
             )}
 
-            <Button
-              variant="contained"
-              color="primary"
-              className={classes.downloadButton}
-              onClick={downloadFinalTestResults}
-            >
-              <DownloadIcon />
-              Download report results
-            </Button>
-            <Button
-              variant="outlined"
-              style={{ backgroundColor: '#FFFFFF', borderColor: '#8891AA' }}
-              onClick={() => window.location.reload()}
-            >
-              Restart test
-            </Button>
-            <img
-              src={testsPassed ? TestsPassed : SomeFailed}
-              alt={testsPassed ? 'Success' : 'Some Failed'}
-              style={{ marginTop: '7em' }}
-            />
+            <div className={classes.buttonContainer}>
+              <Button
+                variant="contained"
+                color="primary"
+                className={classes.downloadButton}
+                onClick={downloadFinalTestResults}
+              >
+                <DownloadIcon />
+                Download report results
+              </Button>
+              <Button variant="outlined" className={classes.restartButton} onClick={() => window.location.reload()}>
+                Restart test
+              </Button>
+            </div>
+
+            <Hidden mdDown>
+              <img
+                src={testsPassed ? TestsPassed : SomeFailed}
+                alt={testsPassed ? 'Success' : 'Some Failed'}
+                className={classes.illustration}
+              />
+            </Hidden>
           </Grid>
 
-          <Grid item md={5}>
+          <Grid item lg={5} className={classes.resultsList}>
             <div className={classes.resultContainer}>
               <div className={classes.iconContainer}>
                 <CheckMark />
-                <Typography variant="h3" gutterBottom>
+                <Typography variant="h3" className={classes.gutterBottom}>
                   Device &amp; Network Setup
                 </Typography>
               </div>
-              <Typography variant="body1" gutterBottom>
+              <Typography variant="body1" className={classes.gutterBottom}>
                 Audio and video successfully received from your hardware and browser.
               </Typography>
-              <Button
-                variant="outlined"
-                onClick={() => dispatch({ type: 'set-active-pane', newActivePane: ActivePane.CameraTest })}
-                style={{ marginRight: '1.5em' }}
-              >
-                Review hardware
-              </Button>
-              <Button
-                variant="outlined"
-                onClick={() => dispatch({ type: 'set-active-pane', newActivePane: ActivePane.BrowserTest })}
-              >
-                Review browser
-              </Button>
+
+              <div className={classes.buttonContainer}>
+                <Button
+                  variant="outlined"
+                  onClick={() => dispatch({ type: 'set-active-pane', newActivePane: ActivePane.CameraTest })}
+                >
+                  Review hardware
+                </Button>
+                <Button
+                  variant="outlined"
+                  onClick={() => dispatch({ type: 'set-active-pane', newActivePane: ActivePane.BrowserTest })}
+                >
+                  Review browser
+                </Button>
+              </div>
             </div>
 
             <div className={classes.resultContainer}>
               <div className={classes.iconContainer}>
                 <CheckMark />
-                <Typography variant="h3" gutterBottom>
+                <Typography variant="h3" className={classes.gutterBottom}>
                   Connectivity
                 </Typography>
               </div>
-              <Typography variant="body1" gutterBottom>
+              <Typography variant="body1" className={classes.gutterBottom}>
                 All connections are working successfully.
               </Typography>
               <Button
@@ -131,20 +171,20 @@ export function Results() {
             <div className={classes.resultContainer}>
               <div className={classes.iconContainer}>
                 {testsPassed ? <CheckMark /> : <SmallError />}
-                <Typography variant="h3" gutterBottom>
+                <Typography variant="h3" className={classes.gutterBottom}>
                   Quality &amp; Performance
                 </Typography>
               </div>
 
               {testsPassed ? (
-                <Typography variant="body1" gutterBottom>
+                <Typography variant="body1" className={classes.gutterBottom}>
                   Awesome! Your expected call quality is <strong>{qualityScore}</strong> and overall performance looks
                   {qualityScore === 'excellent' ? ' good' : ' ok'}.
                 </Typography>
               ) : (
-                <Typography variant="body1" gutterBottom>
+                <Typography variant="body1" className={classes.gutterBottom}>
                   Your overall score is <strong>{qualityScore}</strong> which means that your connection isn't good
-                  enough to run video properly. Try out these tips and rerun the test
+                  enough to run video properly. Try out these tips and rerun the test.
                 </Typography>
               )}
 
@@ -156,7 +196,7 @@ export function Results() {
               </Button>
             </div>
           </Grid>
-        </Grid>
+        </div>
       </Container>
     </>
   );

--- a/src/components/panes/Results/Results.tsx
+++ b/src/components/panes/Results/Results.tsx
@@ -14,6 +14,7 @@ const useStyles = makeStyles((theme: Theme) =>
       float: 'left',
       [theme.breakpoints.down('md')]: {
         float: 'initial',
+        paddingBottom: '1em',
       },
     },
     buttonContainer: {

--- a/src/components/panes/Results/Results.tsx
+++ b/src/components/panes/Results/Results.tsx
@@ -64,6 +64,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     gutterBottom: {
       marginBottom: '1em',
+      [theme.breakpoints.down('md')]: {
+        marginBottom: '1.5em',
+      },
     },
   })
 );

--- a/src/components/panes/Results/__snapshots__/Results.test.tsx.snap
+++ b/src/components/panes/Results/__snapshots__/Results.test.tsx.snap
@@ -3,13 +3,11 @@
 exports[`the GetResults component should render correctly when score is "excellent" 1`] = `
 <Fragment>
   <WithStyles(ForwardRef(Container))>
-    <WithStyles(ForwardRef(Grid))
-      container={true}
-      justifyContent="space-between"
-    >
+    <div>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-header-1"
         item={true}
-        md={5}
+        lg={5}
       >
         <WithStyles(ForwardRef(Typography))
           gutterBottom={true}
@@ -23,95 +21,94 @@ exports[`the GetResults component should render correctly when score is "excelle
         >
           As far as we can tell, your video should be working. If you're still experiencing issues, download your report results and send to your network administrator.
         </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Button))
-          className="makeStyles-downloadButton-3"
-          color="primary"
-          onClick={[MockFunction]}
-          variant="contained"
+        <div
+          className="makeStyles-buttonContainer-2"
         >
-          <DownloadIcon />
-          Download report results
-        </WithStyles(ForwardRef(Button))>
-        <WithStyles(ForwardRef(Button))
-          onClick={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#8891AA",
-            }
-          }
-          variant="outlined"
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-downloadButton-6"
+            color="primary"
+            onClick={[MockFunction]}
+            variant="contained"
+          >
+            <DownloadIcon />
+            Download report results
+          </WithStyles(ForwardRef(Button))>
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-restartButton-7"
+            onClick={[Function]}
+            variant="outlined"
+          >
+            Restart test
+          </WithStyles(ForwardRef(Button))>
+        </div>
+        <Hidden
+          mdDown={true}
         >
-          Restart test
-        </WithStyles(ForwardRef(Button))>
-        <img
-          alt="Success"
-          src="test-file-stub"
-          style={
-            Object {
-              "marginTop": "7em",
-            }
-          }
-        />
+          <img
+            alt="Success"
+            className="makeStyles-illustration-8"
+            src="test-file-stub"
+          />
+        </Hidden>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-resultsList-3"
         item={true}
-        md={5}
+        lg={5}
       >
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Device & Network Setup
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Audio and video successfully received from your hardware and browser.
           </WithStyles(ForwardRef(Typography))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            style={
-              Object {
-                "marginRight": "1.5em",
-              }
-            }
-            variant="outlined"
+          <div
+            className="makeStyles-buttonContainer-2"
           >
-            Review hardware
-          </WithStyles(ForwardRef(Button))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            variant="outlined"
-          >
-            Review browser
-          </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review hardware
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review browser
+            </WithStyles(ForwardRef(Button))>
+          </div>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Connectivity
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             All connections are working successfully.
@@ -124,21 +121,21 @@ exports[`the GetResults component should render correctly when score is "excelle
           </WithStyles(ForwardRef(Button))>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Quality & Performance
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Awesome! Your expected call quality is 
@@ -157,7 +154,7 @@ exports[`the GetResults component should render correctly when score is "excelle
           </WithStyles(ForwardRef(Button))>
         </div>
       </WithStyles(ForwardRef(Grid))>
-    </WithStyles(ForwardRef(Grid))>
+    </div>
   </WithStyles(ForwardRef(Container))>
 </Fragment>
 `;
@@ -165,13 +162,11 @@ exports[`the GetResults component should render correctly when score is "excelle
 exports[`the GetResults component should render correctly when score is "good" 1`] = `
 <Fragment>
   <WithStyles(ForwardRef(Container))>
-    <WithStyles(ForwardRef(Grid))
-      container={true}
-      justifyContent="space-between"
-    >
+    <div>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-header-1"
         item={true}
-        md={5}
+        lg={5}
       >
         <WithStyles(ForwardRef(Typography))
           gutterBottom={true}
@@ -185,95 +180,94 @@ exports[`the GetResults component should render correctly when score is "good" 1
         >
           As far as we can tell, your video should be working. If you're still experiencing issues, download your report results and send to your network administrator.
         </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Button))
-          className="makeStyles-downloadButton-3"
-          color="primary"
-          onClick={[MockFunction]}
-          variant="contained"
+        <div
+          className="makeStyles-buttonContainer-2"
         >
-          <DownloadIcon />
-          Download report results
-        </WithStyles(ForwardRef(Button))>
-        <WithStyles(ForwardRef(Button))
-          onClick={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#8891AA",
-            }
-          }
-          variant="outlined"
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-downloadButton-6"
+            color="primary"
+            onClick={[MockFunction]}
+            variant="contained"
+          >
+            <DownloadIcon />
+            Download report results
+          </WithStyles(ForwardRef(Button))>
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-restartButton-7"
+            onClick={[Function]}
+            variant="outlined"
+          >
+            Restart test
+          </WithStyles(ForwardRef(Button))>
+        </div>
+        <Hidden
+          mdDown={true}
         >
-          Restart test
-        </WithStyles(ForwardRef(Button))>
-        <img
-          alt="Success"
-          src="test-file-stub"
-          style={
-            Object {
-              "marginTop": "7em",
-            }
-          }
-        />
+          <img
+            alt="Success"
+            className="makeStyles-illustration-8"
+            src="test-file-stub"
+          />
+        </Hidden>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-resultsList-3"
         item={true}
-        md={5}
+        lg={5}
       >
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Device & Network Setup
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Audio and video successfully received from your hardware and browser.
           </WithStyles(ForwardRef(Typography))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            style={
-              Object {
-                "marginRight": "1.5em",
-              }
-            }
-            variant="outlined"
+          <div
+            className="makeStyles-buttonContainer-2"
           >
-            Review hardware
-          </WithStyles(ForwardRef(Button))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            variant="outlined"
-          >
-            Review browser
-          </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review hardware
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review browser
+            </WithStyles(ForwardRef(Button))>
+          </div>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Connectivity
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             All connections are working successfully.
@@ -286,21 +280,21 @@ exports[`the GetResults component should render correctly when score is "good" 1
           </WithStyles(ForwardRef(Button))>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Quality & Performance
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Awesome! Your expected call quality is 
@@ -319,7 +313,7 @@ exports[`the GetResults component should render correctly when score is "good" 1
           </WithStyles(ForwardRef(Button))>
         </div>
       </WithStyles(ForwardRef(Grid))>
-    </WithStyles(ForwardRef(Grid))>
+    </div>
   </WithStyles(ForwardRef(Container))>
 </Fragment>
 `;
@@ -327,13 +321,11 @@ exports[`the GetResults component should render correctly when score is "good" 1
 exports[`the GetResults component should render correctly when score is "poor" 1`] = `
 <Fragment>
   <WithStyles(ForwardRef(Container))>
-    <WithStyles(ForwardRef(Grid))
-      container={true}
-      justifyContent="space-between"
-    >
+    <div>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-header-1"
         item={true}
-        md={5}
+        lg={5}
       >
         <WithStyles(ForwardRef(Typography))
           gutterBottom={true}
@@ -350,95 +342,94 @@ exports[`the GetResults component should render correctly when score is "poor" 1
           </strong>
           tests failed – use this list to solve common video issues and restart the test. If you can’t easily solve the problem(s), download report results and send to your network administrator.
         </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Button))
-          className="makeStyles-downloadButton-3"
-          color="primary"
-          onClick={[MockFunction]}
-          variant="contained"
+        <div
+          className="makeStyles-buttonContainer-2"
         >
-          <DownloadIcon />
-          Download report results
-        </WithStyles(ForwardRef(Button))>
-        <WithStyles(ForwardRef(Button))
-          onClick={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#8891AA",
-            }
-          }
-          variant="outlined"
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-downloadButton-6"
+            color="primary"
+            onClick={[MockFunction]}
+            variant="contained"
+          >
+            <DownloadIcon />
+            Download report results
+          </WithStyles(ForwardRef(Button))>
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-restartButton-7"
+            onClick={[Function]}
+            variant="outlined"
+          >
+            Restart test
+          </WithStyles(ForwardRef(Button))>
+        </div>
+        <Hidden
+          mdDown={true}
         >
-          Restart test
-        </WithStyles(ForwardRef(Button))>
-        <img
-          alt="Some Failed"
-          src="test-file-stub"
-          style={
-            Object {
-              "marginTop": "7em",
-            }
-          }
-        />
+          <img
+            alt="Some Failed"
+            className="makeStyles-illustration-8"
+            src="test-file-stub"
+          />
+        </Hidden>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-resultsList-3"
         item={true}
-        md={5}
+        lg={5}
       >
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Device & Network Setup
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Audio and video successfully received from your hardware and browser.
           </WithStyles(ForwardRef(Typography))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            style={
-              Object {
-                "marginRight": "1.5em",
-              }
-            }
-            variant="outlined"
+          <div
+            className="makeStyles-buttonContainer-2"
           >
-            Review hardware
-          </WithStyles(ForwardRef(Button))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            variant="outlined"
-          >
-            Review browser
-          </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review hardware
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review browser
+            </WithStyles(ForwardRef(Button))>
+          </div>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Connectivity
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             All connections are working successfully.
@@ -451,28 +442,28 @@ exports[`the GetResults component should render correctly when score is "poor" 1
           </WithStyles(ForwardRef(Button))>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <SmallError />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Quality & Performance
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Your overall score is 
             <strong>
               poor
             </strong>
-             which means that your connection isn't good enough to run video properly. Try out these tips and rerun the test
+             which means that your connection isn't good enough to run video properly. Try out these tips and rerun the test.
           </WithStyles(ForwardRef(Typography))>
           <WithStyles(ForwardRef(Button))
             onClick={[Function]}
@@ -482,7 +473,7 @@ exports[`the GetResults component should render correctly when score is "poor" 1
           </WithStyles(ForwardRef(Button))>
         </div>
       </WithStyles(ForwardRef(Grid))>
-    </WithStyles(ForwardRef(Grid))>
+    </div>
   </WithStyles(ForwardRef(Container))>
 </Fragment>
 `;
@@ -490,13 +481,11 @@ exports[`the GetResults component should render correctly when score is "poor" 1
 exports[`the GetResults component should render correctly when score is "suboptimal" 1`] = `
 <Fragment>
   <WithStyles(ForwardRef(Container))>
-    <WithStyles(ForwardRef(Grid))
-      container={true}
-      justifyContent="space-between"
-    >
+    <div>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-header-1"
         item={true}
-        md={5}
+        lg={5}
       >
         <WithStyles(ForwardRef(Typography))
           gutterBottom={true}
@@ -513,95 +502,94 @@ exports[`the GetResults component should render correctly when score is "subopti
           </strong>
           tests failed – use this list to solve common video issues and restart the test. If you can’t easily solve the problem(s), download report results and send to your network administrator.
         </WithStyles(ForwardRef(Typography))>
-        <WithStyles(ForwardRef(Button))
-          className="makeStyles-downloadButton-3"
-          color="primary"
-          onClick={[MockFunction]}
-          variant="contained"
+        <div
+          className="makeStyles-buttonContainer-2"
         >
-          <DownloadIcon />
-          Download report results
-        </WithStyles(ForwardRef(Button))>
-        <WithStyles(ForwardRef(Button))
-          onClick={[Function]}
-          style={
-            Object {
-              "backgroundColor": "#FFFFFF",
-              "borderColor": "#8891AA",
-            }
-          }
-          variant="outlined"
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-downloadButton-6"
+            color="primary"
+            onClick={[MockFunction]}
+            variant="contained"
+          >
+            <DownloadIcon />
+            Download report results
+          </WithStyles(ForwardRef(Button))>
+          <WithStyles(ForwardRef(Button))
+            className="makeStyles-restartButton-7"
+            onClick={[Function]}
+            variant="outlined"
+          >
+            Restart test
+          </WithStyles(ForwardRef(Button))>
+        </div>
+        <Hidden
+          mdDown={true}
         >
-          Restart test
-        </WithStyles(ForwardRef(Button))>
-        <img
-          alt="Some Failed"
-          src="test-file-stub"
-          style={
-            Object {
-              "marginTop": "7em",
-            }
-          }
-        />
+          <img
+            alt="Some Failed"
+            className="makeStyles-illustration-8"
+            src="test-file-stub"
+          />
+        </Hidden>
       </WithStyles(ForwardRef(Grid))>
       <WithStyles(ForwardRef(Grid))
+        className="makeStyles-resultsList-3"
         item={true}
-        md={5}
+        lg={5}
       >
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Device & Network Setup
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Audio and video successfully received from your hardware and browser.
           </WithStyles(ForwardRef(Typography))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            style={
-              Object {
-                "marginRight": "1.5em",
-              }
-            }
-            variant="outlined"
+          <div
+            className="makeStyles-buttonContainer-2"
           >
-            Review hardware
-          </WithStyles(ForwardRef(Button))>
-          <WithStyles(ForwardRef(Button))
-            onClick={[Function]}
-            variant="outlined"
-          >
-            Review browser
-          </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review hardware
+            </WithStyles(ForwardRef(Button))>
+            <WithStyles(ForwardRef(Button))
+              onClick={[Function]}
+              variant="outlined"
+            >
+              Review browser
+            </WithStyles(ForwardRef(Button))>
+          </div>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <CheckMark />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Connectivity
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             All connections are working successfully.
@@ -614,28 +602,28 @@ exports[`the GetResults component should render correctly when score is "subopti
           </WithStyles(ForwardRef(Button))>
         </div>
         <div
-          className="makeStyles-resultContainer-1"
+          className="makeStyles-resultContainer-4"
         >
           <div
-            className="makeStyles-iconContainer-2"
+            className="makeStyles-iconContainer-5"
           >
             <SmallError />
             <WithStyles(ForwardRef(Typography))
-              gutterBottom={true}
+              className="makeStyles-gutterBottom-10"
               variant="h3"
             >
               Quality & Performance
             </WithStyles(ForwardRef(Typography))>
           </div>
           <WithStyles(ForwardRef(Typography))
-            gutterBottom={true}
+            className="makeStyles-gutterBottom-10"
             variant="body1"
           >
             Your overall score is 
             <strong>
               suboptimal
             </strong>
-             which means that your connection isn't good enough to run video properly. Try out these tips and rerun the test
+             which means that your connection isn't good enough to run video properly. Try out these tips and rerun the test.
           </WithStyles(ForwardRef(Typography))>
           <WithStyles(ForwardRef(Button))
             onClick={[Function]}
@@ -645,7 +633,7 @@ exports[`the GetResults component should render correctly when score is "subopti
           </WithStyles(ForwardRef(Button))>
         </div>
       </WithStyles(ForwardRef(Grid))>
-    </WithStyles(ForwardRef(Grid))>
+    </div>
   </WithStyles(ForwardRef(Container))>
 </Fragment>
 `;


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-6759](https://issues.corp.twilio.com/browse/VIDEO-6759)

### Description

This PR adds mobile designs for the Results page. Instead of making the pane scrollable, I made some of the padding and margins smaller, though I am open to other suggestions.


**iPad Air Screenshots**:
![IMG_0017](https://user-images.githubusercontent.com/77076398/157138836-1d52241d-dc8a-4920-b79a-3f75fafec27c.PNG)


![IMG_29114B0640F4-1](https://user-images.githubusercontent.com/77076398/157143049-3474049d-651d-45ce-9e38-588b3098aa76.jpeg)




## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [x] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
