### PR TITLE
add width 100% to audio and camera tests

### DIFF
--- a/src/components/panes/AudioTest/AudioTest.tsx
+++ b/src/components/panes/AudioTest/AudioTest.tsx
@@ -19,9 +19,7 @@ const useStyles = makeStyles((theme: Theme) =>
       borderRadius: '8px',
       minHeight: '280px',
       maxWidth: '365px',
-      [theme.breakpoints.down('md')]: {
-        width: '100%',
-      },
+      width: '100%',
     },
     audioLevelContainer: {
       display: 'flex',
@@ -40,6 +38,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     audioTest: {
+      width: '100%',
       float: 'right',
       marginRight: '1em',
       [theme.breakpoints.down('md')]: {

--- a/src/components/panes/CameraTest/CameraTest.tsx
+++ b/src/components/panes/CameraTest/CameraTest.tsx
@@ -63,6 +63,7 @@ const useStyles = makeStyles((theme: Theme) =>
       },
     },
     cameraTest: {
+      width: '100%',
       float: 'right',
       marginRight: '1em',
       [theme.breakpoints.down('md')]: {


### PR DESCRIPTION
<!-- Describe your Pull Request. You may remove some parts that are not applicable. -->

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.

## Pull Request Details

### JIRA link(s):

- [VIDEO-10834](https://issues.corp.twilio.com/browse/VIDEO-10834)

### Description

This PR adds a width of 100% to the `<AudioTest />` and `<CameraTest />` components so that they stay the same width regardless of the selected device:

![Screen Shot 2022-08-03 at 2 30 01 PM](https://user-images.githubusercontent.com/77076398/182715675-8569e43a-7014-4cbd-9f27-53fae69e843a.png)

## Burndown

### Before review
* [ ] Updated CHANGELOG.md if necessary
* [ ] Added unit tests if necessary
* [ ] Updated affected documentation
* [x] Verified locally with `npm test`
* [x] Manually sanity tested running locally
* [x] Included screenshot as PR comment (if needed)
* [x] Ready for review

### Before merge
* [ ] Got one or more +1s
* [ ] Re-tested if necessary
